### PR TITLE
Add Notification Channel resource and its handling

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,30 +2,39 @@
 
 
 [[projects]]
+  digest = "1:dc2ba13235a4c8f80a40599575a3f10acb4736cb372f1a68b88333c06564471d"
   name = "github.com/agext/levenshtein"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5f10fee965225ac1eecdc234c09daf5cd9e7f7b6"
   version = "v1.2.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:ef98942770803ae37c4787ad6bf70e401c99834dfba5e3034b97ba7c24e66c10"
   name = "github.com/apparentlymart/go-cidr"
   packages = ["cidr"]
+  pruneopts = "UT"
   revision = "2bd8b58cf4275aeb086ade613de226773e29e853"
 
 [[projects]]
   branch = "master"
+  digest = "1:2bf7da77216264bb61bd8cb5f3380a03ab509e8a826fe359008d4a6ba0789b13"
   name = "github.com/apparentlymart/go-textseg"
   packages = ["textseg"]
+  pruneopts = "UT"
   revision = "b836f5c4d331d1945a2fead7188db25432d73b69"
 
 [[projects]]
   branch = "master"
+  digest = "1:9fd3a6ab34bb103ba228eefd044d3f9aa476237ea95a46d12e8cccd3abf3fea2"
   name = "github.com/armon/go-radix"
   packages = ["."]
+  pruneopts = "UT"
   revision = "1fca145dffbcaa8fe914309b1ec0cfc67500fe61"
 
 [[projects]]
+  digest = "1:0f2558ef357af91d20e51ac7e7ddf4ba1e756e3a0b2a51130005f9a46fc0a12b"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -57,118 +66,152 @@
     "private/protocol/restxml",
     "private/protocol/xml/xmlutil",
     "service/s3",
-    "service/sts"
+    "service/sts",
   ]
+  pruneopts = "UT"
   revision = "16cb9f62f8a8b7af4f38725567f5ce762e1d562b"
   version = "v1.14.21"
 
 [[projects]]
   branch = "master"
+  digest = "1:37011b20a70e205b93ebea5287e1afa5618db54bf3998c36ff5a8e4b146a170a"
   name = "github.com/bgentry/go-netrc"
   packages = ["netrc"]
+  pruneopts = "UT"
   revision = "9fd32a8b3d3d3f9d43c341bfe098430e07609480"
 
 [[projects]]
+  digest = "1:1343a2963481a305ca4d051e84bc2abd16b601ee22ed324f8d605de1adb291b0"
   name = "github.com/bgentry/speakeasy"
   packages = ["."]
+  pruneopts = "UT"
   revision = "4aabc24848ce5fd31929f7d1e4ea74d3709c14cd"
   version = "v0.1.0"
 
 [[projects]]
+  digest = "1:705c40022f5c03bf96ffeb6477858d88565064485a513abcd0f11a0911546cb6"
   name = "github.com/blang/semver"
   packages = ["."]
+  pruneopts = "UT"
   revision = "2ee87856327ba09384cabd113bc6b5d174e9ec0f"
   version = "v3.5.1"
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "UT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:865079840386857c809b72ce300be7580cb50d3d3129ce11bf9aa6ca2bc1934a"
   name = "github.com/fatih/color"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5b77d2a35fb0ede96d138fc9a99f5c9b6aef11b4"
   version = "v1.7.0"
 
 [[projects]]
+  digest = "1:fb46255681497314debedde38b64be32a75bae50bad107586c22f1662bf2d352"
   name = "github.com/go-ini/ini"
   packages = ["."]
+  pruneopts = "UT"
   revision = "06f5f3d67269ccec1fe5fe4134ba6e982984f7f5"
   version = "v1.37.0"
 
 [[projects]]
+  digest = "1:17fe264ee908afc795734e8c4e63db2accabaf57326dbf21763a7d6b86096260"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp"
+    "ptypes/timestamp",
   ]
+  pruneopts = "UT"
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:07671f8997086ed115824d1974507d2b147d1e0463675ea5dbf3be89b1c2c563"
   name = "github.com/hashicorp/errwrap"
   packages = ["."]
+  pruneopts = "UT"
   revision = "7554cd9344cec97297fa6649b055a8c98c2a1e55"
 
 [[projects]]
   branch = "master"
+  digest = "1:77cb3be9b21ba7f1a4701e870c84ea8b66e7d74c7c8951c58155fdadae9414ec"
   name = "github.com/hashicorp/go-cleanhttp"
   packages = ["."]
+  pruneopts = "UT"
   revision = "d5fe4b57a186c716b0e00b8c301cbd9b4182694d"
 
 [[projects]]
   branch = "master"
+  digest = "1:49be3bd056300f2156364200a3dd871cdc548adf09242ea6d4353d512574834c"
   name = "github.com/hashicorp/go-getter"
   packages = [
     ".",
-    "helper/url"
+    "helper/url",
   ]
+  pruneopts = "UT"
   revision = "3f60ec5cfbb2a39731571b9ddae54b303bb0a969"
 
 [[projects]]
   branch = "master"
+  digest = "1:39e3c6a08d969bd30057f542ef0bdc08db97c04e708a61bb0a774b320a7296b2"
   name = "github.com/hashicorp/go-hclog"
   packages = ["."]
+  pruneopts = "UT"
   revision = "69ff559dc25f3b435631604f573a5fa1efdb6433"
 
 [[projects]]
   branch = "master"
+  digest = "1:e5048c5da80697be2fcdecc944e29d2999e01fd7f48b643168443209779f3463"
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
+  pruneopts = "UT"
   revision = "b7773ae218740a7be65057fc60b366a49b538a44"
 
 [[projects]]
   branch = "master"
+  digest = "1:82320f8469d1524df337bc315a38c87644765cd89ec4cf3cbda249a3acdde671"
   name = "github.com/hashicorp/go-plugin"
   packages = ["."]
+  pruneopts = "UT"
   revision = "e8d22c780116115ae5624720c9af0c97afe4f551"
 
 [[projects]]
   branch = "master"
+  digest = "1:0fd42c2104e1b30aaee9f4f538fadef25290f5196dd1973166bcf51bb71f66f4"
   name = "github.com/hashicorp/go-safetemp"
   packages = ["."]
+  pruneopts = "UT"
   revision = "b1a1dbde6fdc11e3ae79efd9039009e22d4ae240"
 
 [[projects]]
   branch = "master"
+  digest = "1:354978aad16c56c27f57e5b152224806d87902e4935da3b03e18263d82ae77aa"
   name = "github.com/hashicorp/go-uuid"
   packages = ["."]
+  pruneopts = "UT"
   revision = "27454136f0364f2d44b1276c552d69105cf8c498"
 
 [[projects]]
   branch = "master"
+  digest = "1:e12b92b8bb20af6e299e9829534cfe790857702a988d3f0443e772c9d82a4fd2"
   name = "github.com/hashicorp/go-version"
   packages = ["."]
+  pruneopts = "UT"
   revision = "23480c0665776210b5fbbac6eaaee40e3e6a96b7"
 
 [[projects]]
   branch = "master"
+  digest = "1:12247a2e99a060cc692f6680e5272c8adf0b8f572e6bce0d7095e624c958a240"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -179,12 +222,14 @@
     "hcl/token",
     "json/parser",
     "json/scanner",
-    "json/token"
+    "json/token",
   ]
+  pruneopts = "UT"
   revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
 
 [[projects]]
   branch = "master"
+  digest = "1:45242582b3c102d45f99291ee6cac83d2427a0686d1ab1f0fa0ddd12b09710d8"
   name = "github.com/hashicorp/hcl2"
   packages = [
     "gohcl",
@@ -192,22 +237,26 @@
     "hcl/hclsyntax",
     "hcl/json",
     "hcldec",
-    "hclparse"
+    "hclparse",
   ]
+  pruneopts = "UT"
   revision = "1718a963e6321c0d8b663ca3f2224be366d59905"
 
 [[projects]]
   branch = "master"
+  digest = "1:a0fcb763bbae723b790db78143ac713c2a96c7542a4e1a2628ba3a9aedd13ae9"
   name = "github.com/hashicorp/hil"
   packages = [
     ".",
     "ast",
     "parser",
-    "scanner"
+    "scanner",
   ]
+  pruneopts = "UT"
   revision = "fa9f258a92500514cc8e9c67020487709df92432"
 
 [[projects]]
+  digest = "1:f9df5f5f00b4621ad6a8cab0f32346d9e95a43351b1a33e6a90625751d88fdd6"
   name = "github.com/hashicorp/terraform"
   packages = [
     "config",
@@ -233,124 +282,160 @@
     "svchost/disco",
     "terraform",
     "tfdiags",
-    "version"
+    "version",
   ]
+  pruneopts = "UT"
   revision = "41e50bd32a8825a84535e353c3674af8ce799161"
   version = "v0.11.7"
 
 [[projects]]
   branch = "master"
+  digest = "1:89658943622e6bc5e76b4da027ee9583fa0b321db0c797bd554edab96c1ca2b1"
   name = "github.com/hashicorp/yamux"
   packages = ["."]
+  pruneopts = "UT"
   revision = "3520598351bb3500a49ae9563f5539666ae0a27c"
 
 [[projects]]
+  digest = "1:e22af8c7518e1eab6f2eab2b7d7558927f816262586cd6ed9f349c97a6c285c4"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
+  pruneopts = "UT"
   revision = "0b12d6b5"
 
 [[projects]]
+  digest = "1:c658e84ad3916da105a761660dcaeb01e63416c8ec7bc62256a9b411a05fcd67"
   name = "github.com/mattn/go-colorable"
   packages = ["."]
+  pruneopts = "UT"
   revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
   version = "v0.0.9"
 
 [[projects]]
+  digest = "1:d4d17353dbd05cb52a2a52b7fe1771883b682806f68db442b436294926bbfafb"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
+  pruneopts = "UT"
   revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
   version = "v0.0.3"
 
 [[projects]]
   branch = "master"
+  digest = "1:0fbbd0f1fa0d71a357594b0f40b25458eccbe1809d95843e81129b93e7a7b1cb"
   name = "github.com/mitchellh/cli"
   packages = ["."]
+  pruneopts = "UT"
   revision = "c48282d14eba4b0817ddef3f832ff8d13851aefd"
 
 [[projects]]
   branch = "master"
+  digest = "1:dfb4eb6168a4e7f16e9fda5b9164013a0f5a8eb06bb5ca3a1980964a7beedde4"
   name = "github.com/mitchellh/copystructure"
   packages = ["."]
+  pruneopts = "UT"
   revision = "d23ffcb85de31694d6ccaa23ccb4a03e55c1303f"
 
 [[projects]]
   branch = "master"
+  digest = "1:8eb17c2ec4df79193ae65b621cd1c0c4697db3bc317fe6afdc76d7f2746abd05"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
+  pruneopts = "UT"
   revision = "3864e76763d94a6df2f9960b16a20a33da9f9a66"
 
 [[projects]]
   branch = "master"
+  digest = "1:cae1afe858922bd10e9573b87130f730a6e4183a00eba79920d6656629468bfa"
   name = "github.com/mitchellh/go-testing-interface"
   packages = ["."]
+  pruneopts = "UT"
   revision = "a61a99592b77c9ba629d254a693acffaeb4b7e28"
 
 [[projects]]
   branch = "master"
+  digest = "1:e68cd472b96cdf7c9f6971ac41bcc1d4d3b23d67c2a31d2399446e295bc88ae9"
   name = "github.com/mitchellh/go-wordwrap"
   packages = ["."]
+  pruneopts = "UT"
   revision = "ad45545899c7b13c020ea92b2072220eefad42b8"
 
 [[projects]]
   branch = "master"
+  digest = "1:544635141f5fb084637823f438f3563be046a9730c256d2e7760dbb741cd88b5"
   name = "github.com/mitchellh/hashstructure"
   packages = ["."]
+  pruneopts = "UT"
   revision = "2bca23e0e452137f789efbc8610126fd8b94f73b"
 
 [[projects]]
   branch = "master"
+  digest = "1:e730597b38a4d56e2361e0b6236cb800e52c73cace2ff91396f4ff35792ddfa7"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
+  pruneopts = "UT"
   revision = "bb74f1db0675b241733089d5a1faa5dd8b0ef57b"
 
 [[projects]]
   branch = "master"
+  digest = "1:012bcbda750df8b57e302656a0820833eaa98009a7546b22620283c65996743b"
   name = "github.com/mitchellh/reflectwalk"
   packages = ["."]
+  pruneopts = "UT"
   revision = "63d60e9d0dbc60cf9164e6510889b0db6683d98c"
 
 [[projects]]
+  digest = "1:9ec6cf1df5ad1d55cf41a43b6b1e7e118a91bade4f68ff4303379343e40c0e25"
   name = "github.com/oklog/run"
   packages = ["."]
+  pruneopts = "UT"
   revision = "4dadeb3030eda0273a12382bb2348ffc7c9d1a39"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:4d76324ccff5546792b4274c5fe1639bc5983c533c85d1b4be2168d57daabdf0"
   name = "github.com/posener/complete"
   packages = [
     ".",
     "cmd",
     "cmd/install",
-    "match"
+    "match",
   ]
+  pruneopts = "UT"
   revision = "98eb9847f27ba2008d380a32c98be474dea55bdf"
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:18752d0b95816a1b777505a97f71c7467a8445b8ffb55631a7bf779f6ba4fa83"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
+  pruneopts = "UT"
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
 [[projects]]
+  digest = "1:4aeb3860275fa1fd60cccfb5a6ef85da438bf17402e1e84412ade4d4b55066a0"
   name = "github.com/ulikunitz/xz"
   packages = [
     ".",
     "internal/hash",
     "internal/xlog",
-    "lzma"
+    "lzma",
   ]
+  pruneopts = "UT"
   revision = "0c6b41e72360850ca4f98dc341fd999726ea007f"
   version = "v0.5.4"
 
 [[projects]]
   branch = "master"
+  digest = "1:34c512c2e2033bc473dd486f162e1e9ae36522d86a45d53702e60b448f10ba57"
   name = "github.com/zclconf/go-cty"
   packages = [
     "cty",
@@ -359,12 +444,14 @@
     "cty/function/stdlib",
     "cty/gocty",
     "cty/json",
-    "cty/set"
+    "cty/set",
   ]
+  pruneopts = "UT"
   revision = "3ccef1ae92b0ac73b92d86f274f0ff781e2d9b3b"
 
 [[projects]]
   branch = "master"
+  digest = "1:f0c8ff8cea29d50958d6b76e265ab9aba20771bd6af15010088528f0a89978b4"
   name = "golang.org/x/crypto"
   packages = [
     "bcrypt",
@@ -375,12 +462,14 @@
     "openpgp/elgamal",
     "openpgp/errors",
     "openpgp/packet",
-    "openpgp/s2k"
+    "openpgp/s2k",
   ]
+  pruneopts = "UT"
   revision = "a49355c7e3f8fe157a85be2f77e6e269a0f89602"
 
 [[projects]]
   branch = "master"
+  digest = "1:51e551087c7f3b081c6c0a456956a5d3b3c481999ebc7854d04149617019255b"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -391,17 +480,21 @@
     "http2/hpack",
     "idna",
     "internal/timeseries",
-    "trace"
+    "trace",
   ]
+  pruneopts = "UT"
   revision = "6f138e0f60713a248abf7046f1014a3ba90f5341"
 
 [[projects]]
   branch = "master"
+  digest = "1:d773e525476aefa22ea944a5425a9bfb99819b2e67eeb9b1966454fd57522bbf"
   name = "golang.org/x/sys"
   packages = ["unix"]
+  pruneopts = "UT"
   revision = "1b2967e3c290b7c545b3db0deeda16e9be4f98a2"
 
 [[projects]]
+  digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -417,18 +510,22 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
   ]
+  pruneopts = "UT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:601e63e7d4577f907118bec825902505291918859d223bce015539e79f1160e3"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
+  pruneopts = "UT"
   revision = "8b2cc369ab52e0003a878865c9372afdd6ca5c5a"
 
 [[projects]]
+  digest = "1:1a9c0243b6fc4ccd431b2ac2eb964b453db89e0465bab46a718695f8a7f25bfb"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -457,14 +554,21 @@
     "stats",
     "status",
     "tap",
-    "transport"
+    "transport",
   ]
+  pruneopts = "UT"
   revision = "168a6198bcb0ef175f7dacec0b8691fc141dc9b8"
   version = "v1.13.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5eda7f5e449f347aaa82e093e7172f6848b45f9e4f7a446b09e89d14a0e86a82"
+  input-imports = [
+    "github.com/hashicorp/terraform/helper/schema",
+    "github.com/hashicorp/terraform/helper/validation",
+    "github.com/hashicorp/terraform/plugin",
+    "github.com/hashicorp/terraform/terraform",
+    "github.com/stretchr/testify/assert",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/examples/create-secure-policy/main.tf
+++ b/examples/create-secure-policy/main.tf
@@ -4,6 +4,52 @@ resource "sysdig_secure_user_rules_file" "this" {
   content = "${file("${path.module}/rules-traefik.yaml")}"
 }
 
+resource "sysdig_secure_notification_channel" "sample-email" {
+  name = "Example Channel - Email"
+  enabled = true
+  type = "EMAIL"
+  recipients = "root@localhost.com"
+  notify_when_ok = false
+  notify_when_resolved = false
+}
+
+resource "sysdig_secure_notification_channel" "sample-amazon-sns" {
+  name = "Example Channel - Amazon SNS"
+  enabled = true
+  type = "SNS"
+  topics = "arn:aws:sns:us-east-1:273107874544:my-alerts,arn:aws:sns:us-east-1:273107874544:my-alerts2"
+  notify_when_ok = false
+  notify_when_resolved = false
+}
+
+resource "sysdig_secure_notification_channel" "sample-victorops" {
+  name = "Example Channel - VictorOps"
+  enabled = true
+  type = "VICTOROPS"
+  api_key = "1234342-4234243-4234-2"
+  routing_key = "My team"
+  notify_when_ok = false
+  notify_when_resolved = false
+}
+
+resource "sysdig_secure_notification_channel" "sample-opsgenie" {
+  name = "Example Channel - OpsGenie"
+  enabled = true
+  type = "OPSGENIE"
+  api_key = "2349324-342354353-5324-23"
+  notify_when_ok = false
+  notify_when_resolved = false
+}
+
+resource "sysdig_secure_notification_channel" "sample-webhook" {
+  name = "Example Channel - Webhook"
+  enabled = true
+  type = "WEBHOOK"
+  url = "localhost:8080"
+  notify_when_ok = false
+  notify_when_resolved = false
+}
+
 resource "sysdig_secure_policy" "sample" {
   name = "Write apt stuff"
   description = "an attempt to write to the dpkg database by any non-dpkg related program"

--- a/examples/create-secure-policy/main.tf
+++ b/examples/create-secure-policy/main.tf
@@ -61,6 +61,10 @@ resource "sysdig_secure_policy" "sample" {
   container_scope = true
   host_scope = true
 
+  notification_channels = [
+    "${sysdig_secure_notification_channel.sample-email.id}",
+    "${sysdig_secure_notification_channel.sample-opsgenie.id}"]
+
   //actions {
   //  container = "pause"
 

--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -20,8 +20,9 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"sysdig_secure_policy":          resourceSysdigSecurePolicy(),
-			"sysdig_secure_user_rules_file": resourceSysdigSecureUserRulesFile(),
+			"sysdig_secure_policy":               resourceSysdigSecurePolicy(),
+			"sysdig_secure_user_rules_file":      resourceSysdigSecureUserRulesFile(),
+			"sysdig_secure_notification_channel": resourceSysdigSecureNotificationChannel(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/sysdig/resource_sysdig_secure_notification_channel.go
+++ b/sysdig/resource_sysdig_secure_notification_channel.go
@@ -1,0 +1,243 @@
+package sysdig
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func resourceSysdigSecureNotificationChannel() *schema.Resource {
+	timeout := 30 * time.Second
+
+	return &schema.Resource{
+		Create: resourceSysdigNotificationChannelCreate,
+		Update: resourceSysdigNotificationChannelUpdate,
+		Read:   resourceSysdigNotificationChannelRead,
+		Delete: resourceSysdigNotificationChannelDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(timeout),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"recipients": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"topics": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"api_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"routing_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"url": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"notify_when_ok": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"notify_when_resolved": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceSysdigNotificationChannelCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(SysdigSecureClient)
+
+	notificationChannel, err := notificationChannelFromResourceData(d)
+	if err != nil {
+		return err
+	}
+
+	notificationChannel, err = client.CreateNotificationChannel(notificationChannel)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(strconv.Itoa(notificationChannel.ID))
+	d.Set("version", notificationChannel.Version)
+
+	return nil
+}
+
+// Retrieves the information of a resource form the file and loads it in Terraform
+func resourceSysdigNotificationChannelRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(SysdigSecureClient)
+
+	id, _ := strconv.Atoi(d.Id())
+	nc, err := client.GetNotificationChannelById(id)
+
+	if err != nil {
+		d.SetId("")
+	}
+
+	d.Set("version", nc.Version)
+	d.Set("name", nc.Name)
+	d.Set("enabled", nc.Enabled)
+	d.Set("type", nc.Type)
+	d.Set("recipients", nc.Options.EmailRecipients)
+	d.Set("topics", nc.Options.SnsTopicARNs)
+	d.Set("api_key", nc.Options.APIKey)
+	d.Set("url", nc.Options.Url)
+	d.Set("routing_key", nc.Options.RoutingKey)
+	d.Set("notify_when_ok", nc.Options.NotifyOnOk)
+	d.Set("notify_when_resolved", nc.Options.NotifyOnResolve)
+
+	// When we receive a notification channel of type OpsGenie,
+	// the API sends us the URL, but we are configuring the API
+	// key in the file, so terraform identifies this as a change in
+	// the resource and tries to update it remotely even if it
+	// didn't change at all.
+	// We need to extract the key from the url the API gives us
+	// to avoid this Terraform's behaviour.
+	if nc.Type == opsgenie {
+		regex, err := regexp.Compile("apiKey=(.*)?$")
+		if err != nil {
+			return err
+		}
+		key := regex.FindStringSubmatch(nc.Options.Url)[1]
+		d.Set("api_key", key)
+		d.Set("url", "")
+	}
+	return nil
+}
+
+func resourceSysdigNotificationChannelUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(SysdigSecureClient)
+
+	nc, err := notificationChannelFromResourceData(d)
+	if err != nil {
+		return err
+	}
+
+	nc.Version = d.Get("version").(int)
+	nc.ID, _ = strconv.Atoi(d.Id())
+
+	_, err = client.UpdateNotificationChannel(nc)
+
+	return err
+}
+
+func resourceSysdigNotificationChannelDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(SysdigSecureClient)
+
+	id, _ := strconv.Atoi(d.Id())
+
+	return client.DeleteNotificationChannel(id)
+}
+
+// Channel type for Notification Channels
+const (
+	email     = "EMAIL"
+	amazonSns = "SNS"
+	opsgenie  = "OPSGENIE"
+	victorops = "VICTOROPS"
+	webhook   = "WEBHOOK"
+)
+
+func notificationChannelFromResourceData(d *schema.ResourceData) (nc NotificationChannel, err error) {
+
+	channelType := strings.ToUpper(d.Get("type").(string))
+
+	nc = NotificationChannel{
+		Name:    d.Get("name").(string),
+		Enabled: d.Get("enabled").(bool),
+		Type:    channelType,
+		Options: NotificationChannelOptions{
+			NotifyOnOk:      d.Get("notify_when_ok").(bool),
+			NotifyOnResolve: d.Get("notify_when_resolved").(bool),
+		},
+	}
+
+	fieldNotSetError := "the '%s' field must be set when the type of the notification channel is %s"
+
+	// Retrieve the special options for each type
+	switch channelType {
+	case email:
+		if recipients, ok := d.Get("recipients").(string); ok && recipients != "" {
+			emails := strings.Split(recipients, ",")
+			for _, email := range emails {
+				// We need to trim the emails or the API will not accept them
+				nc.Options.EmailRecipients = append(nc.Options.EmailRecipients, strings.TrimSpace(email))
+			}
+		} else {
+			err = fmt.Errorf(fieldNotSetError, "recipients", channelType)
+			return
+		}
+	case amazonSns:
+		if snsTopics, ok := d.Get("topics").(string); ok && snsTopics != "" {
+			topics := strings.Split(snsTopics, ",")
+			for _, topic := range topics {
+				// We need to trim the topics or the API will not accept them
+				nc.Options.SnsTopicARNs = append(nc.Options.SnsTopicARNs, strings.TrimSpace(topic))
+			}
+		} else {
+			err = fmt.Errorf(fieldNotSetError, "topics", channelType)
+			return
+		}
+	case victorops:
+		if apiKey, ok := d.Get("api_key").(string); ok && apiKey != "" {
+			nc.Options.APIKey = apiKey
+		} else {
+			err = fmt.Errorf(fieldNotSetError, "api_key", channelType)
+			return
+		}
+
+		if routingKey, ok := d.Get("routing_key").(string); ok && routingKey != "" {
+			nc.Options.RoutingKey = routingKey
+		} else {
+			err = fmt.Errorf(fieldNotSetError, "routing_key", channelType)
+			return
+		}
+	case opsgenie:
+		if apiKey, ok := d.Get("api_key").(string); ok && apiKey != "" {
+			nc.Options.Url = fmt.Sprintf("https://api.opsgenie.com/v1/json/sysdigcloud?apiKey=%s", apiKey)
+		} else {
+			err = fmt.Errorf(fieldNotSetError, "api_key", channelType)
+			return
+		}
+	case webhook:
+		if url, ok := d.Get("url").(string); ok && url != "" {
+			nc.Options.Url = url
+		} else {
+			err = fmt.Errorf(fieldNotSetError, "url", channelType)
+			return
+		}
+	default:
+		validChannelTypes := []string{email, amazonSns, opsgenie, victorops, webhook}
+		err = fmt.Errorf("error type not recognized, must be one of the following: %s", validChannelTypes)
+		return
+	}
+
+	return
+}

--- a/sysdig/sysdig_secure_client.go
+++ b/sysdig/sysdig_secure_client.go
@@ -117,6 +117,7 @@ func (client *sysdigSecureClient) GetNotificationChannelUrl(id int) string {
 }
 
 // == Policy ===========================================================================================================
+
 func (client *sysdigSecureClient) CreatePolicy(policyRequest Policy) (Policy, error) {
 	response, _ := client.doSysdigSecureRequest("POST", client.policiesURL(), policyRequest.ToJSON())
 	body, _ := ioutil.ReadAll(response.Body)

--- a/sysdig/sysdig_secure_models.go
+++ b/sysdig/sysdig_secure_models.go
@@ -17,6 +17,8 @@ type FalcoConfiguration struct {
 	RuleNameRegEx string `json:"ruleNameRegEx"`
 }
 
+// -------- Policies --------
+
 type Policy struct {
 	ID                 int                `json:"id,omitempty"`
 	Name               string             `json:"name"`
@@ -47,6 +49,8 @@ func PolicyFromJSON(body []byte) Policy {
 	return result.Policy
 }
 
+// -------- User Rules File --------
+
 type UserRulesFile struct {
 	Content string `json:"content"`
 	Version int    `json:"version"`
@@ -66,4 +70,45 @@ func UserRulesFileFromJSON(body []byte) UserRulesFile {
 	json.Unmarshal(body, &result)
 
 	return result.UserRulesFile
+}
+
+// -------- Notification Channels --------
+
+type NotificationChannelOptions struct {
+	EmailRecipients []string `json:"emailRecipients,omitempty"` // Type: email
+
+	SnsTopicARNs []string `json:"snsTopicARNs,omitempty"` // Type: SNS
+
+	APIKey     string `json:"apiKey,omitempty"`     // Type: VictorOps
+	RoutingKey string `json:"routingKey,omitempty"` // Type: VictorOps
+
+	Url string `json:"url,omitempty"` // Type: OpsGenie and Webhook
+
+	NotifyOnOk      bool `json:"notifyOnOk"`
+	NotifyOnResolve bool `json:"notifyOnResolve"`
+}
+
+type NotificationChannel struct {
+	ID      int                        `json:"id,omitempty"`
+	Version int                        `json:"version,omitempty"`
+	Type    string                     `json:"type"`
+	Name    string                     `json:"name"`
+	Enabled bool                       `json:"enabled"`
+	Options NotificationChannelOptions `json:"options"`
+}
+
+func (n NotificationChannel) ToJSON() io.Reader {
+	payload, _ := json.Marshal(notificationChannelWrapper{n})
+	return bytes.NewBuffer(payload)
+}
+
+func NotificationChannelFromJSON(body []byte) NotificationChannel {
+	var result notificationChannelWrapper
+	json.Unmarshal(body, &result)
+
+	return result.NotificationChannel
+}
+
+type notificationChannelWrapper struct {
+	NotificationChannel NotificationChannel `json:"notificationChannel"`
 }

--- a/sysdig/sysdig_secure_models.go
+++ b/sysdig/sysdig_secure_models.go
@@ -20,17 +20,18 @@ type FalcoConfiguration struct {
 // -------- Policies --------
 
 type Policy struct {
-	ID                 int                `json:"id,omitempty"`
-	Name               string             `json:"name"`
-	Description        string             `json:"description"`
-	Severity           int                `json:"severity"`
-	ContainerScope     bool               `json:"containerScope"`
-	HostScope          bool               `json:"hostScope"`
-	Enabled            bool               `json:"enabled"`
-	Actions            []Action           `json:"actions,omitempty"`
-	Scope              string             `json:"scope,omitempty"`
-	FalcoConfiguration FalcoConfiguration `json:"falcoConfiguration,omitempty"`
-	Version            int                `json:"version,omitempty"`
+	ID                     int                `json:"id,omitempty"`
+	Name                   string             `json:"name"`
+	Description            string             `json:"description"`
+	Severity               int                `json:"severity"`
+	ContainerScope         bool               `json:"containerScope"`
+	HostScope              bool               `json:"hostScope"`
+	Enabled                bool               `json:"enabled"`
+	Actions                []Action           `json:"actions,omitempty"`
+	Scope                  string             `json:"scope,omitempty"`
+	FalcoConfiguration     FalcoConfiguration `json:"falcoConfiguration,omitempty"`
+	Version                int                `json:"version,omitempty"`
+	NotificationChannelIds []string           `json:"notificationChannelIds,omitempty"`
 }
 
 type policyWrapper struct {


### PR DESCRIPTION
This Pull Request adds the Notification Channel resource and some examples.
In this changes, there's support for the following channel types: 

- [X] Email 
- [ ] PagerDuty
- [ ] Slack
- [X] Amazon SNS
- [X] VictorOps
- [X] OpsGenie
- [X] WebHook

It also adds references from the Policies to the Notification Channels