### PR TITLE
Add team resource for Sysdig Secure

### DIFF
--- a/examples/team.tf
+++ b/examples/team.tf
@@ -1,0 +1,19 @@
+resource "sysdig_secure_team" "sample" {
+  name               = "sample-team"
+  description        = "sample"
+  scope_by           = "container"
+  filter             = "container.image.repo = \"sysdig/agent\""
+  use_sysdig_capture = false
+
+  user_roles {
+    email = "sample@example.com"
+    role  = "ROLE_TEAM_STANDARD"
+  }
+
+  user_roles {
+    email = "sample2@example.com"
+    role  = "ROLE_TEAM_EDIT"
+  }
+
+}
+

--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -44,6 +44,7 @@ func Provider() terraform.ResourceProvider {
 			"sysdig_secure_rule_syscall":         resourceSysdigSecureRuleSyscall(),
 			"sysdig_secure_rule_falco":           resourceSysdigSecureRuleFalco(),
 			"sysdig_user":                        resourceSysdigUser(),
+			"sysdig_secure_team":                 resourceSysdigSecureTeam(),
 
 			"sysdig_monitor_alert_downtime":      resourceSysdigMonitorAlertDowntime(),
 			"sysdig_monitor_alert_metric":        resourceSysdigMonitorAlertMetric(),

--- a/sysdig/resource_sysdig_secure_team.go
+++ b/sysdig/resource_sysdig_secure_team.go
@@ -1,0 +1,167 @@
+package sysdig
+
+import (
+	"github.com/draios/terraform-provider-sysdig/sysdig/secure"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"strconv"
+	"time"
+)
+
+func resourceSysdigSecureTeam() *schema.Resource {
+	timeout := 30 * time.Second
+
+	return &schema.Resource{
+		Create: resourceSysdigTeamCreate,
+		Update: resourceSysdigTeamUpdate,
+		Read:   resourceSysdigTeamRead,
+		Delete: resourceSysdigTeamDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(timeout),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"theme": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "#73A1F7",
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"scope_by": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "container",
+			},
+			"filter": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"use_sysdig_capture": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"user_roles": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"email": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"role": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "ROLE_TEAM_STANDARD",
+						},
+					},
+				},
+			},
+			"default_team": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceSysdigTeamCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*SysdigClients).sysdigSecureClient
+
+	team := teamFromResourceData(d)
+
+	team, err := client.CreateTeam(team)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(strconv.Itoa(team.ID))
+	d.Set("version", team.Version)
+
+	return nil
+}
+
+// Retrieves the information of a resource form the file and loads it in Terraform
+func resourceSysdigTeamRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*SysdigClients).sysdigSecureClient
+
+	id, _ := strconv.Atoi(d.Id())
+	t, err := client.GetTeamById(id)
+
+	if err != nil {
+		d.SetId("")
+		return err
+	}
+
+	d.Set("version", t.Version)
+	d.Set("theme", t.Theme)
+	d.Set("name", t.Name)
+	d.Set("description", t.Description)
+	d.Set("scope_by", t.ScopeBy)
+	d.Set("filter", t.Filter)
+	d.Set("canUseSysdigCapture", t.CanUseSysdigCapture)
+	d.Set("default_team", t.DefaultTeam)
+	d.Set("user_roles", t.UserRoles)
+
+	return nil
+}
+
+func resourceSysdigTeamUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*SysdigClients).sysdigSecureClient
+
+	t := teamFromResourceData(d)
+
+	t.Version = d.Get("version").(int)
+	t.ID, _ = strconv.Atoi(d.Id())
+
+	_, err := client.UpdateTeam(t)
+
+	return err
+}
+
+func resourceSysdigTeamDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*SysdigClients).sysdigSecureClient
+
+	id, _ := strconv.Atoi(d.Id())
+
+	return client.DeleteTeam(id)
+}
+
+func teamFromResourceData(d *schema.ResourceData) secure.Team {
+	t := secure.Team{
+		Theme:               d.Get("theme").(string),
+		Name:                d.Get("name").(string),
+		Description:         d.Get("description").(string),
+		ScopeBy:             d.Get("scope_by").(string),
+		Filter:              d.Get("filter").(string),
+		CanUseSysdigCapture: d.Get("use_sysdig_capture").(bool),
+		DefaultTeam:         d.Get("default_team").(bool),
+		Products:            []string{"SDS"},
+	}
+
+	userRoles := []secure.UserRoles{}
+	for _, userRole := range d.Get("user_roles").(*schema.Set).List() {
+		ur := userRole.(map[string]interface{})
+		userRoles = append(userRoles, secure.UserRoles{
+			Email: ur["email"].(string),
+			Role:  ur["role"].(string),
+		})
+	}
+	t.UserRoles = userRoles
+
+	return t
+}

--- a/sysdig/resource_sysdig_secure_team_test.go
+++ b/sysdig/resource_sysdig_secure_team_test.go
@@ -1,0 +1,106 @@
+package sysdig_test
+
+import (
+	"fmt"
+	"github.com/draios/terraform-provider-sysdig/sysdig"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"os"
+	"testing"
+)
+
+func TestAccTeam(t *testing.T) {
+	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			if v := os.Getenv("SYSDIG_SECURE_API_TOKEN"); v == "" {
+				t.Fatal("SYSDIG_SECURE_API_TOKEN must be set for acceptance tests")
+			}
+		},
+		Providers: map[string]terraform.ResourceProvider{
+			"sysdig": sysdig.Provider(),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: teamWithName(rText()),
+			},
+			{
+				Config: teamWithOneUser(rText()),
+			},
+			{
+				Config: teamWithTwoUser(rText()),
+			},
+			{
+				Config: teamMinimumConfiguration(rText()),
+			},
+		},
+	})
+}
+
+func teamWithName(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_team" "sample" {
+  name               = "sample-%s"
+  description        = "%s"
+  scope_by           = "container"
+  filter             = "container.image.repo = \"sysdig/agent\""
+}`, name, name)
+}
+
+func teamWithOneUser(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_user" "sample" {
+  email      = "terraform-test+team@sysdig.com"
+}
+
+resource "sysdig_secure_team" "sample" {
+  name               = "sample-%s"
+  description        = "%s"
+  scope_by           = "container"
+  filter             = "container.image.repo = \"sysdig/agent\""
+  use_sysdig_capture = false
+
+  user_roles {
+    email = sysdig_user.sample.email
+    role  = "ROLE_TEAM_EDIT"
+  }
+}`, name, name)
+}
+
+func teamWithTwoUser(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_user" "sample1" {
+  email      = "terraform-test+team-1@sysdig.com"
+}
+
+resource "sysdig_user" "sample2" {
+  email      = "terraform-test+team-2@sysdig.com"
+}
+
+resource "sysdig_secure_team" "sample" {
+  name               = "sample-%s"
+  description        = "%s"
+  scope_by           = "container"
+  filter             = "container.image.repo = \"sysdig/agent\""
+  use_sysdig_capture = false
+
+  user_roles {
+    email = sysdig_user.sample1.email
+    role  = "ROLE_TEAM_EDIT"
+  }
+
+  user_roles {
+    email = sysdig_user.sample2.email
+    role  = "ROLE_TEAM_MANAGER"
+  }
+}`, name, name)
+}
+
+func teamMinimumConfiguration(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_team" "sample" {
+  name      = "sample-%s"
+}`, name)
+}

--- a/sysdig/secure/client.go
+++ b/sysdig/secure/client.go
@@ -25,6 +25,11 @@ type SysdigSecureClient interface {
 	GetUserById(int) (User, error)
 	DeleteUser(int) error
 	UpdateUser(User) (User, error)
+
+	CreateTeam(Team) (Team, error)
+	GetTeamById(int) (Team, error)
+	DeleteTeam(int) error
+	UpdateTeam(Team) (Team, error)
 }
 
 func NewSysdigSecureClient(sysdigSecureAPIToken string, url string) SysdigSecureClient {

--- a/sysdig/secure/models.go
+++ b/sysdig/secure/models.go
@@ -220,3 +220,57 @@ func UserFromJSON(body []byte) User {
 type userWrapper struct {
 	User User `json:"user"`
 }
+
+// -------- Team --------
+type Team struct {
+	ID                  int         `json:"id,omitempty"`
+	Version             int         `json:"version,omitempty"`
+	Theme               string      `json:"theme"`
+	Name                string      `json:"name"`
+	Description         string      `json:"description"`
+	ScopeBy             string      `json:"show"`
+	Filter              string      `json:"filter"`
+	CanUseSysdigCapture bool        `json:"canUseSysdigCapture"`
+	UserRoles           []UserRoles `json:"userRoles,omitempty"`
+	DefaultTeam         bool        `json:"default"`
+	Products            []string    `json:"products"`
+}
+
+type UserRoles struct {
+	UserId int    `json:"userId"`
+	Email  string `json:"userName",omitempty`
+	Role   string `json:"role"`
+}
+
+func (t *Team) ToJSON() io.Reader {
+	payload, _ := json.Marshal(*t)
+	return bytes.NewBuffer(payload)
+}
+
+func TeamFromJSON(body []byte) Team {
+	var result teamWrapper
+	json.Unmarshal(body, &result)
+
+	return result.Team
+}
+
+type teamWrapper struct {
+	Team Team `json:"team"`
+}
+
+// -------- UsersList --------
+type UsersList struct {
+	ID    int    `json:"id"`
+	Email string `json:"username"`
+}
+
+func UsersListFromJSON(body []byte) []UsersList {
+	var result usersListWrapper
+	json.Unmarshal(body, &result)
+
+	return result.UsersList
+}
+
+type usersListWrapper struct {
+	UsersList []UsersList `json:"users"`
+}

--- a/sysdig/secure/teams.go
+++ b/sysdig/secure/teams.go
@@ -1,0 +1,136 @@
+package secure
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+func (client *sysdigSecureClient) getUserIdbyEmail(userRoles []UserRoles) ([]UserRoles, error) {
+	// Get UsersList from API
+	response, err := client.doSysdigSecureRequest(http.MethodGet, client.getUsersListUrl(), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	body, _ := ioutil.ReadAll(response.Body)
+
+	if response.StatusCode != http.StatusOK {
+		err = errors.New(response.Status)
+		return nil, err
+	}
+
+	// Set User Id to UserRoles struct
+	usersList := UsersListFromJSON(body)
+	usersMap := make(map[string]int)
+	for _, u := range usersList {
+		usersMap[u.Email] = u.ID
+	}
+
+	var modifiedUserRoles []UserRoles
+
+	for _, userRole := range userRoles {
+		ur := userRole
+		id, ok := usersMap[ur.Email]
+		if !ok {
+			return nil, errors.New(ur.Email + " doesn't exist.")
+		}
+		ur.UserId = id
+		modifiedUserRoles = append(modifiedUserRoles, ur)
+	}
+
+	return modifiedUserRoles, nil
+}
+
+func (client *sysdigSecureClient) GetTeamById(id int) (t Team, err error) {
+	response, err := client.doSysdigSecureRequest(http.MethodGet, client.GetTeamUrl(id), nil)
+	if err != nil {
+		return
+	}
+	defer response.Body.Close()
+
+	body, _ := ioutil.ReadAll(response.Body)
+
+	if response.StatusCode != http.StatusOK {
+		err = errors.New(response.Status)
+		return
+	}
+
+	t = TeamFromJSON(body)
+
+	return
+}
+
+func (client *sysdigSecureClient) CreateTeam(tRequest Team) (t Team, err error) {
+	tRequest.UserRoles, err = client.getUserIdbyEmail(tRequest.UserRoles)
+	if err != nil {
+		return
+	}
+
+	response, err := client.doSysdigSecureRequest(http.MethodPost, client.GetTeamsUrl(), tRequest.ToJSON())
+
+	if err != nil {
+		return
+	}
+	defer response.Body.Close()
+
+	body, _ := ioutil.ReadAll(response.Body)
+
+	if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusCreated {
+		err = errors.New(response.Status)
+		return
+	}
+
+	t = TeamFromJSON(body)
+	return
+}
+
+func (client *sysdigSecureClient) UpdateTeam(tRequest Team) (t Team, err error) {
+	tRequest.UserRoles, err = client.getUserIdbyEmail(tRequest.UserRoles)
+	if err != nil {
+		return
+	}
+
+	response, err := client.doSysdigSecureRequest(http.MethodPut, client.GetTeamUrl(tRequest.ID), tRequest.ToJSON())
+	if err != nil {
+		return
+	}
+	defer response.Body.Close()
+
+	body, _ := ioutil.ReadAll(response.Body)
+
+	if response.StatusCode != http.StatusOK {
+		err = errors.New(response.Status)
+		return
+	}
+
+	t = TeamFromJSON(body)
+	return
+}
+
+func (client *sysdigSecureClient) DeleteTeam(id int) error {
+	response, err := client.doSysdigSecureRequest(http.MethodDelete, client.GetTeamUrl(id), nil)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusNoContent && response.StatusCode != http.StatusOK {
+		return errors.New(response.Status)
+	}
+	return nil
+}
+
+func (client *sysdigSecureClient) getUsersListUrl() string {
+	return fmt.Sprintf("%s/api/users/light", client.URL)
+}
+
+func (client *sysdigSecureClient) GetTeamsUrl() string {
+	return fmt.Sprintf("%s/api/teams", client.URL)
+}
+
+func (client *sysdigSecureClient) GetTeamUrl(id int) string {
+	return fmt.Sprintf("%s/api/teams/%d", client.URL, id)
+}


### PR DESCRIPTION
### What
- Add `sysdig_secure_team` resource

### Why
- This PR is related to #11 

### Comment for reviewers
- I think we have additional discussion topic about this PR.
  - So I'll write comment on the point which I want reviewers to check.

### Test result
<details><summary>make testacc</summary><div>

```bash
$ make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v  -timeout 120m
?   	github.com/draios/terraform-provider-sysdig	[no test files]
?   	github.com/draios/terraform-provider-sysdig/scripts/oanc	[no test files]
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestAccAlertAnomaly
=== PAUSE TestAccAlertAnomaly
=== RUN   TestAccAlertDowntime
=== PAUSE TestAccAlertDowntime
=== RUN   TestAccAlertEvent
=== PAUSE TestAccAlertEvent
=== RUN   TestAccAlertGroupOutlier
=== PAUSE TestAccAlertGroupOutlier
=== RUN   TestAccAlertMetric
=== PAUSE TestAccAlertMetric
=== RUN   TestAccNotificationChannel
=== PAUSE TestAccNotificationChannel
=== RUN   TestAccPolicy
=== PAUSE TestAccPolicy
=== RUN   TestAccRuleContainer
--- PASS: TestAccRuleContainer (4.32s)
=== RUN   TestAccRuleFalco
--- PASS: TestAccRuleFalco (2.64s)
=== RUN   TestAccRuleFilesystem
--- PASS: TestAccRuleFilesystem (5.11s)
=== RUN   TestAccRuleNetwork
--- PASS: TestAccRuleNetwork (4.99s)
=== RUN   TestAccRuleProcess
--- PASS: TestAccRuleProcess (2.82s)
=== RUN   TestAccRuleSyscall
--- PASS: TestAccRuleSyscall (2.80s)
=== RUN   TestAccTeam
--- PASS: TestAccTeam (7.42s)
=== RUN   TestAccUser
--- PASS: TestAccUser (4.91s)
=== CONT  TestAccAlertAnomaly
=== CONT  TestAccAlertMetric
=== CONT  TestAccAlertEvent
=== CONT  TestAccAlertGroupOutlier
=== CONT  TestAccAlertDowntime
=== CONT  TestAccPolicy
=== CONT  TestAccNotificationChannel
--- PASS: TestAccAlertDowntime (1.70s)
--- PASS: TestAccAlertEvent (1.71s)
--- PASS: TestAccAlertAnomaly (1.73s)
--- PASS: TestAccAlertGroupOutlier (1.73s)
--- PASS: TestAccAlertMetric (2.53s)
--- PASS: TestAccNotificationChannel (4.45s)
--- PASS: TestAccPolicy (7.22s)
PASS
ok  	github.com/draios/terraform-provider-sysdig/sysdig	44.176s
?   	github.com/draios/terraform-provider-sysdig/sysdig/monitor	[no test files]
?   	github.com/draios/terraform-provider-sysdig/sysdig/secure	[no test files]
```

</div></details>


<details><summary>make test</summary><div>

```bash
$ make test
==> Checking that code complies with gofmt requirements...
go test ./... -timeout=30s -parallel=4
?   	github.com/draios/terraform-provider-sysdig	[no test files]
?   	github.com/draios/terraform-provider-sysdig/scripts/oanc	[no test files]
ok  	github.com/draios/terraform-provider-sysdig/sysdig	0.523s
?   	github.com/draios/terraform-provider-sysdig/sysdig/monitor	[no test files]
?   	github.com/draios/terraform-provider-sysdig/sysdig/secure	[no test files]
PC2292:terraform-provider-sysdig suezawa$
```

</div></details>