### PR TITLE
feat: Add custom headers option to the provider and the client

### DIFF
--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -40,6 +40,11 @@ func Provider() terraform.ResourceProvider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("SYSDIG_MONITOR_INSECURE_TLS", false),
 			},
+			"extra_headers": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"sysdig_user": resourceSysdigUser(),

--- a/sysdig/sysdig_clients.go
+++ b/sysdig/sysdig_clients.go
@@ -41,6 +41,15 @@ func (c *sysdigClients) sysdigMonitorClient() (m monitor.SysdigMonitorClient, er
 			c.d.Get("sysdig_monitor_url").(string),
 			c.d.Get("sysdig_monitor_insecure_tls").(bool),
 		)
+
+		if headers, ok := c.d.GetOk("extra_headers"); ok {
+			extraHeaders := headers.(map[string]interface{})
+			extraHeadersTransformed := map[string]string{}
+			for key := range extraHeaders {
+				extraHeadersTransformed[key] = extraHeaders[key].(string)
+			}
+			c.monitorClient = monitor.WithExtraHeaders(c.monitorClient, extraHeadersTransformed)
+		}
 	})
 
 	return c.monitorClient, nil
@@ -61,6 +70,15 @@ func (c *sysdigClients) sysdigSecureClient() (s secure.SysdigSecureClient, err e
 			c.d.Get("sysdig_secure_url").(string),
 			c.d.Get("sysdig_secure_insecure_tls").(bool),
 		)
+
+		if headers, ok := c.d.GetOk("extra_headers"); ok {
+			extraHeaders := headers.(map[string]interface{})
+			extraHeadersTransformed := map[string]string{}
+			for key := range extraHeaders {
+				extraHeadersTransformed[key] = extraHeaders[key].(string)
+			}
+			c.secureClient = secure.WithExtraHeaders(c.secureClient, extraHeadersTransformed)
+		}
 	})
 
 	return c.secureClient, nil
@@ -92,6 +110,15 @@ func (c *sysdigClients) sysdigCommonClient() (co common.SysdigCommonClient, err 
 			commonURL,
 			commonInsecure,
 		)
+
+		if headers, ok := c.d.GetOk("extra_headers"); ok {
+			extraHeaders := headers.(map[string]interface{})
+			extraHeadersTransformed := map[string]string{}
+			for key := range extraHeaders {
+				extraHeadersTransformed[key] = extraHeaders[key].(string)
+			}
+			c.commonClient = common.WithExtraHeaders(c.commonClient, extraHeadersTransformed)
+		}
 	})
 
 	return c.commonClient, nil


### PR DESCRIPTION
This PR adds an `extra_headers` field to the provider's configuration that would allow users of the provider to authenticate with custom methods. 
The headers can overwrite the existing `Authorization` and `Content-Type`.