### PR TITLE
Support proxy from env vars

### DIFF
--- a/sysdig/secure/client.go
+++ b/sysdig/secure/client.go
@@ -51,6 +51,7 @@ func NewSysdigSecureClient(sysdigSecureAPIToken string, url string, insecure boo
 	httpClient := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
+			Proxy:           http.ProxyFromEnvironment,
 		},
 	}
 


### PR DESCRIPTION
Default Transport in http package supports proxy from standard env variables, see line 37 on:

https://golang.org/src/net/http/transport.go

Using a custom Transport overrides this setting, which is standard and should be supported.